### PR TITLE
Bump to freetype 2.6, fix Tcl/Tk on Mac, better log output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,17 @@ source:
   fn: Pillow-{{ version }}.tar.gz
   url: https://github.com/python-pillow/Pillow/archive/{{ version }}.tar.gz
   sha256: eb4b9c2956e38f89d588a0d0af0e27a03f1e1d2be705a828bbd12cfba0b020fa
+  patches:
+    # Apply the diff from a Pillow PR to add the `--disable-osx-tcltk-framework`
+    # flag. Link below.
+    #
+    # https://github.com/python-pillow/Pillow/pull/1883
+    #
+    - pillow_PR_1883.diff
 
 build:
   number: 2
-  script: pip install --no-deps .
+  script: python setup.py build_ext --debug --disable-osx-tcltk-framework install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,16 @@
+{% set version = "3.2.0" %}
+
 package:
   name: pillow
-  version: 3.2.0
+  version: {{ version }}
 
 source:
-  fn: Pillow-3.2.0.tar.gz
-  url: https://github.com/python-pillow/Pillow/archive/3.2.0.tar.gz
+  fn: Pillow-{{ version }}.tar.gz
+  url: https://github.com/python-pillow/Pillow/archive/{{ version }}.tar.gz
   sha256: eb4b9c2956e38f89d588a0d0af0e27a03f1e1d2be705a828bbd12cfba0b020fa
 
 build:
-  number: 1
+  number: 2
   script: pip install --no-deps .
 
 requirements:
@@ -18,13 +20,13 @@ requirements:
     - zlib 1.2*
     - libtiff 4.0.6
     - jpeg 9*
-    - freetype 2.5*
+    - freetype 2.6*
     - tk
   run:
     - python
     - jpeg 9*
     - zlib 1.2*
-    - freetype 2.5*
+    - freetype 2.6*
     - libtiff 4.0.6
 
 test:

--- a/recipe/pillow_PR_1883.diff
+++ b/recipe/pillow_PR_1883.diff
@@ -1,0 +1,43 @@
+diff --git docs/installation.rst docs/installation.rst
+index c3d3941..bde880c 100644
+--- docs/installation.rst
++++ docs/installation.rst
+@@ -202,6 +202,11 @@ Build Options
+   the libraries are not found. Webpmux (WebP metadata) relies on WebP
+   support. Tcl and Tk also must be used together.
+ 
++* Build flag: ``--disable-osx-tcltk-framework``. Skips linking against
++  the OSX system TCL/TK frameworks for systems that have alternate
++  versions of the libraries installed. 
++
++
+ Sample Usage::
+ 
+     $ MAX_CONCURRENCY=1 python setup.py build_ext --enable-[feature] install
+diff --git setup.py setup.py
+index 0f74a40..873459c 100644
+--- setup.py
++++ setup.py
+@@ -121,9 +121,13 @@ class pil_build_ext(build_ext):
+         ('disable-%s' % x, None, 'Disable support for %s' % x) for x in feature
+     ] + [
+         ('enable-%s' % x, None, 'Enable support for %s' % x) for x in feature
++    ] + [
++        ('disable-osx-tcltk-framework', None,
++             'Disable linking against system tcl/tk frameworks on OSX')
+     ]
+ 
+     def initialize_options(self):
++        self.disable_osx_tcltk_framework = None
+         build_ext.initialize_options(self)
+         for x in self.feature:
+             setattr(self, 'disable_%s' % x, None)
+@@ -580,7 +584,7 @@ class pil_build_ext(build_ext):
+                                   define_macros=defs))
+ 
+         if feature.tcl and feature.tk:
+-            if sys.platform == "darwin":
++            if sys.platform == "darwin" and not self.disable_osx_tcltk_framework:
+                 # locate Tcl/Tk frameworks
+                 frameworks = []
+                 framework_roots = [


### PR DESCRIPTION
* Absorbs @ocefpaf's PR ( https://github.com/conda-forge/pillow-feedstock/pull/6 ) to pin freetype to 2.6 as in the [pinning wiki]( https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies ).
* Uses an upstream PR ( https://github.com/python-pillow/Pillow/pull/1883 ) to fix an issue where the Tcl/Tk framework was linked against on Mac instead of our `tk` package.