### PR TITLE
Drop lingering `--debug` flag

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   number: 2
-  script: python setup.py build_ext --debug --disable-osx-tcltk-framework install --single-version-externally-managed --record=record.txt
+  script: python setup.py build_ext --disable-osx-tcltk-framework install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:


### PR DESCRIPTION
Oops, this crept in somehow. Amazingly it didn't seem to affect the *NIXes, but maybe it broke Windows more? Let's see if this improves the situation.