### PR TITLE
Try to fix Windows Python 3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools 20.7.0  # [win and py35]
     - pip
     - zlib 1.2*
     - libtiff 4.0.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
 requirements:
   build:
     - python
-    - setuptools 20.7.0  # [win and py35]
+    - vs2015_runtime 14.00.23026.0 0   # [win and py35]
     - pip
     - zlib 1.2*
     - libtiff 4.0.6
@@ -32,6 +32,7 @@ requirements:
     - tk
   run:
     - python
+    - vs2015_runtime 14.00.23026.0 0   # [win and py35]
     - jpeg 9*
     - zlib 1.2*
     - freetype 2.6*


### PR DESCRIPTION
An attempt to fix whatever is wrong with Windows Python 3.5.

~~1. Try pinning `setuptools` to the last working version `20.7.0`.~~
2. Try pinning `vs2015_runtime` to the last working version `14.00.23026.0 0`.