### PR TITLE
WIP: Remove pinning of vs2015_runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ build:
 requirements:
   build:
     - python
-    - vs2015_runtime 14.00.23026.0 0   # [win and py35]
     - pip
     - zlib 1.2*
     - libtiff 4.0.6
@@ -32,7 +31,6 @@ requirements:
     - tk
   run:
     - python
-    - vs2015_runtime 14.00.23026.0 0   # [win and py35]
     - jpeg 9*
     - zlib 1.2*
     - freetype 2.6*


### PR DESCRIPTION
**DO NOT MERGE YET! THIS WILL BREAK WINDOWS PYTHON 3.5 BUILDS.**

Just getting this one ready. We ultimately do want to merge this, but not until issue ( https://github.com/conda-forge/staged-recipes/issues/666 ) is resolved.