### PR TITLE
Re-render master with conda-smithy 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: generic
 
 os: osx
+osx_image: beta-xcode6.1
 
 env:
   matrix:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 693eaab8719a6d6a3bc239e5af2474c72062f64266a9b2ace23b5d2ed3a636af
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pillow-feedstock/issues/20

* Re-renders master with conda-smithy 1.3.2
* Bumps the build number to get new packages (particularly for OS X)