### PR TITLE
Release 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pillow
 
 Home: http://python-imaging.github.io/
 
-Package license: Standard PIL license
+Package license: PIL
 
 Feedstock license: BSD 3-Clause
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,11 +32,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -47,7 +47,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "4.1.0" %}
 
 package:
   name: pillow
@@ -7,10 +7,10 @@ package:
 source:
   fn: Pillow-{{ version }}.tar.gz
   url: https://github.com/python-pillow/Pillow/archive/{{ version }}.tar.gz
-  sha256: ece687f83a78db7ac608aaa9469fc4d5dbc22757c5bc814cee75f457382d26bc
+  sha256: a0fd487fed4a35717401b7566e51a1520b34e7c0f7f2a315a6509f82bc86299f
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: http://python-imaging.github.io/
-  license: Standard PIL license
+  license: PIL
   license_file: LICENSE
   summary: 'Pillow is the friendly PIL fork by Alex Clark and Contributors.'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: Pillow-{{ version }}.tar.gz
-  url: https://github.com/python-pillow/Pillow/archive/{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/P/Pillow/Pillow-{{ version }}.tar.gz
   sha256: a0fd487fed4a35717401b7566e51a1520b34e7c0f7f2a315a6509f82bc86299f
 
 build:


### PR DESCRIPTION
```reST
4.1.0 (2017-04-03)
------------------

- Close files after loading if possible #2330
  [homm, wiredfool]

- Fix Image Access to be reloadable when embedding the Python interpreter #2296
  [wiredfool, cgohlke]

- Fetch DPI from EXIF if not specified in JPEG header #2449, #2472
  [hugovk]

- Removed winbuild checksum verification #2468
  [radarhere]

- Git: Set ContainerIO test file as binary #2469
  [cgohlke]
  
- Remove superfluous import of FixTk #2455
  [cgohlke)

- Fix import of tkinter/Tkinter #2456
  [cgohlke)

- Pure Python Decoders, including Python decoder to fix for MSP images #1938
  [wiredfool, hugovk]
  
- Reorganized GifImagePlugin, fixes #2314.  #2374
  [radarhere, wiredfool]

- Doc: Reordered operating systems in Compatibility Matrix #2436
  [radarhere]

- Test: Additional tests for BurfStub, Eps, Container, GribStub, IPTC, Wmf, XVThumb, ImageDraw, ImageMorph ImageShow #2425
  [radarhere]
 
- Health fixes #2437
  [radarhere]
  
- Test: Correctness tests ContainerIO, XVThumbImagePlugin, BufrStubImagePlugin, GribStubImagePlugin, FitsStubImagePlugin, Hdf5StubImagePlugin, PixarImageFile, PsdImageFile #2443, #2442, #2441, #2440, #2431, #2430, #2428, #2427
  [hugovk]

- Remove unused imports #1822
  [radarhere]

- Replaced KeyError catch with dictionary get method #2424
  [radarhere]

- Test: Removed unrunnable code in test_image_toqimage #2415
  [hugovk]

- Removed use of spaces in TIFF kwargs names, deprecated in 2.7 #1390
  [radarhere]

- Removed deprecated ImageDraw setink, setfill, setfont methods #2220
  [jdufresne]

- Send unwanted subprocess output to /dev/null #2253
  [jdufresne]

- Fix division by zero when creating 0x0 image from numpy array #2419
  [hugovk]

- Test: Added matrix convert tests #2381
  [hugovk]

- Replaced broken URL to partners.adobe.com #2413
  [radarhere]

- Removed unused private functions in setup.py and build_dep.py #2414
  [radarhere]

- Test: Fixed Qt tests for QT5 and saving 1 bit PNG #2394
  [wiredfool]

- Test: docker builds for Arch and Debian Stretch #2394
  [wiredfool]

- Updated libwebp to 0.6.0 on appveyor #2395
  [radarhere]

- More explicit error message when saving to a file with invalid extension #2399
  [ces42]

- Docs: Update some http urls to https #2403
  [hugovk]

- Preserve aux/alpha channels when performing Imagecms transforms #2355
  [gunjambi]

- Test linear and radial gradient effects #2382
  [hugovk]

- Test ImageDraw.Outline and and ImageDraw.Shape #2389
  [hugovk]

- Added PySide to ImageQt documentation #2392
  [radarhere]

- BUG: Empty image mode no longer causes a crash #2380
  [evalapply]

- Exclude .travis and contents from manifest #2386
  [radarhere]

- Remove 'MIT-like' from license #2145
  [wiredfool]

- Tests: Add tests for several Image operations #2379
  [radarhere]

- PNG: Moved iCCP chunk before PLTE chunk when saving as PNG, restricted chunks known value/ordering #2347
  [radarhere]

- Default to inch-interpretation for missing ResolutionUnit in TiffImagePlugin #2365
  [lambdafu]

- Bug: Fixed segfault when using ImagingTk on pypy Issue #2376, #2359.
  [wiredfool]

- Bug: Fixed Integer overflow using ImagingTk on 32 bit platforms #2359
  [wiredfool, QuLogic]

- Tests: Added docker images for testing alternate platforms. See also https://github.com/python-pillow/docker-images. #2368
  [wiredfool]

- Removed PIL 1.0 era TK readme that concerns Windows 95/NT #2360
  [wiredfool]

- Prevent `nose -v` printing docstrings #2369
  [hugovk]

- Replaced absolute PIL imports with relative imports #2349
  [radarhere]

- Added context managers for file handling #2307
  [radarhere]

- Expose registered file extensions in Image #2343
  [iggomez, radarhere]

- Make mode descriptor cache initialization thread-safe. #2351
  [gunjambi]

- Updated Windows test dependencies: Freetype 2.7.1, zlib 1.2.11 #2331, #2332, #2357
  [radarhere]

- Followed upstream pngquant packaging reorg to libimagquant #2354
  [radarhere]

- Fix invalid string escapes #2352
  [hugovk]

- Add test for crop operation with no argument #2333
  [radarhere]
```