### PR TITLE
Build with compatibility for libtiff 4.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,12 @@ source:
     - patches/0003-add-WEBP_ROOT-XCB_ROOT.patch
     # fix provided by upstream maintainer for failing test
     - patches/0004-Added-patch-to-fix-failing-Windows-test.patch
+    # Can be removed in the release after 9.1.1
+    # https://github.com/python-pillow/Pillow/pull/6339
+    - patches/6339_libtiff_4_4_0_compatibility.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/patches/6339_libtiff_4_4_0_compatibility.patch
+++ b/recipe/patches/6339_libtiff_4_4_0_compatibility.patch
@@ -1,0 +1,43 @@
+From 0a4a7722b532489a71a16072d4d1d73334dbce71 Mon Sep 17 00:00:00 2001
+From: Andrew Murray <radarhere@users.noreply.github.com>
+Date: Sat, 21 May 2022 10:13:10 +1000
+Subject: [PATCH 1/2] Updated libtiff to 4.4.0
+
+---
+ src/libImaging/TiffDecode.c | 14 +++-----------
+ 1 file changed, 3 insertions(+), 11 deletions(-)
+
+diff --git a/src/libImaging/TiffDecode.c b/src/libImaging/TiffDecode.c
+index f818f19d50..3bb444c804 100644
+--- a/src/libImaging/TiffDecode.c
++++ b/src/libImaging/TiffDecode.c
+@@ -815,11 +815,11 @@ ImagingLibTiffMergeFieldInfo(
+ 
+     // custom fields added with ImagingLibTiffMergeFieldInfo are only used for
+     // decoding, ignore readcount;
+-    int readcount = 1;
++    int readcount = is_var_length ? TIFF_VARIABLE : 1;
+     // we support writing a single value, or a variable number of values
+-    int writecount = 1;
++    int writecount = is_var_length ? TIFF_VARIABLE : 1;
+     // whether the first value should encode the number of values.
+-    int passcount = 0;
++    int passcount = (is_var_length && field_type != TIFF_ASCII) ? 1 : 0;
+ 
+     TIFFFieldInfo info[] = {
+         {key,
+@@ -831,14 +831,6 @@ ImagingLibTiffMergeFieldInfo(
+          passcount,
+          "CustomField"}};
+ 
+-    if (is_var_length) {
+-        info[0].field_writecount = -1;
+-    }
+-
+-    if (is_var_length && field_type != TIFF_ASCII) {
+-        info[0].field_passcount = 1;
+-    }
+-
+     n = sizeof(info) / sizeof(info[0]);
+ 
+     // Test for libtiff 4.0 or later, excluding libtiff 3.9.6 and 3.9.7


### PR DESCRIPTION
Do we need to patch older builds to mark them as incompatible? 

This is always the question with this kind of stuff.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
